### PR TITLE
Add JOSS citation to landing page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -25,7 +25,9 @@ Contact us by [email](mailto:intangible.realities.lab+nanover@gmail.com).
 
 ### Latest publications
 
-> Free energy along drug-protein binding pathways interactively sampled in virtual reality Deeks, H.M., Zinovjev, K., Barnoud, J. et al. Sci Rep 13, 16665 (2023). https://doi.org/10.1038/s41598-023-43523-x
+> Stroud, H. J., Wonnacott, M. D., Barnoud, J., Roebuck Williams, R., Dhouioui, M., McSloy, A., Aisa, L., Toledo, L. E., Bates, P., Mulholland, A. J., & Glowacki, D. R. (2025). NanoVer Server: A Python Package for Serving Real-Time Multi-User Interactive Molecular Dynamics in Virtual Reality. *Journal of Open Source Software*, *10* (110), 8118. https://doi.org/10.21105/joss.08118
+
+> Deeks, H. M., Zinovjev, K., Barnoud, J., Mulholland, A. J., van der Kamp, M. W., & Glowacki, D. R. (2023). Free energy along drug-protein binding pathways interactively sampled in virtual reality. *Scientific Reports*, *13*, 16665. https://doi.org/10.1038/s41598-023-43523-x
 
 See all publications in the [IRL website](https://www.intangiblerealitieslab.org/publications)
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -25,9 +25,13 @@ Contact us by [email](mailto:intangible.realities.lab+nanover@gmail.com).
 
 ### Latest publications
 
-> Stroud, H. J., Wonnacott, M. D., Barnoud, J., Roebuck Williams, R., Dhouioui, M., McSloy, A., Aisa, L., Toledo, L. E., Bates, P., Mulholland, A. J., & Glowacki, D. R. (2025). NanoVer Server: A Python Package for Serving Real-Time Multi-User Interactive Molecular Dynamics in Virtual Reality. *Journal of Open Source Software*, *10* (110), 8118. https://doi.org/10.21105/joss.08118
+> Stroud, H. J., Wonnacott, M. D., Barnoud, J., Roebuck Williams, R., Dhouioui, M., McSloy, A., Aisa, L., Toledo, L. E., Bates, P., Mulholland, A. J., & Glowacki, D. R. (2025). NanoVer Server: A Python Package for Serving Real-Time Multi-User Interactive Molecular Dynamics in Virtual Reality. *Journal of Open Source Software*, *10* (110), 8118. 
+> \
+> https://doi.org/10.21105/joss.08118
 
-> Deeks, H. M., Zinovjev, K., Barnoud, J., Mulholland, A. J., van der Kamp, M. W., & Glowacki, D. R. (2023). Free energy along drug-protein binding pathways interactively sampled in virtual reality. *Scientific Reports*, *13*, 16665. https://doi.org/10.1038/s41598-023-43523-x
+> Deeks, H. M., Zinovjev, K., Barnoud, J., Mulholland, A. J., van der Kamp, M. W., & Glowacki, D. R. (2023). Free energy along drug-protein binding pathways interactively sampled in virtual reality. *Scientific Reports*, *13*, 16665.
+> \
+> https://doi.org/10.1038/s41598-023-43523-x
 
 See all publications in the [IRL website](https://www.intangiblerealitieslab.org/publications)
 


### PR DESCRIPTION
This PR adds the citation for the NanoVer JOSS paper to the landing page of the NanoVer website, and reformats the existing citation to match the format of the citations on the IRL website.